### PR TITLE
[New example] API Hooking

### DIFF
--- a/apihooking/Cargo.toml
+++ b/apihooking/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "apihooking"
+version = "0.1.0"
+authors = ["Idov31 <github.com/idov31>"]
+edition = "2021"
+
+[[bin]]
+name = "apihooking"
+path = "src/main.rs"
+
+[dependencies]
+winapi = {version = "0.3.9", features = ["winuser"]}
+win32-error = "0.9.0"
+detour = "0.8.1"

--- a/apihooking/src/main.rs
+++ b/apihooking/src/main.rs
@@ -17,14 +17,6 @@ static_detour! {
     static MsgBox: unsafe extern "system" fn(HWND, LPCSTR, LPCSTR, UINT) -> i32;
 }
 
-unsafe fn hooked_messagebox(hwnd: HWND, lp_text: LPCSTR, lp_caption: LPCSTR, u_type: UINT) -> i32 {
-    println!("Hooked MessageBoxA");
-
-    unsafe {
-        MsgBox.call(hwnd, lp_text, lp_caption, u_type)
-    }
-}
-
 
 fn main() {
     unsafe {

--- a/apihooking/src/main.rs
+++ b/apihooking/src/main.rs
@@ -1,0 +1,40 @@
+use std::ffi::CString;
+use winapi::{
+    um::{
+        winuser::MessageBoxA, 
+    },
+    shared::{
+        windef::HWND, 
+        minwindef::{
+            UINT
+        }, 
+        ntdef::LPCSTR
+    }
+};
+use detour::static_detour;
+
+static_detour! {
+    static MsgBox: unsafe extern "system" fn(HWND, LPCSTR, LPCSTR, UINT) -> i32;
+}
+
+unsafe fn hooked_messagebox(hwnd: HWND, lp_text: LPCSTR, lp_caption: LPCSTR, u_type: UINT) -> i32 {
+    println!("Hooked MessageBoxA");
+
+    unsafe {
+        MsgBox.call(hwnd, lp_text, lp_caption, u_type)
+    }
+}
+
+
+fn main() {
+    unsafe {
+        MsgBox.initialize(MessageBoxA, |hwnd, lp_text, lp_caption, u_type| {
+            println!("Hooked MessageBoxA");
+                MsgBox.call(hwnd, lp_text, lp_caption, u_type)
+        });
+        MessageBoxA(0 as HWND, CString::new("Before").unwrap().as_ptr(), CString::new("Before").unwrap().as_ptr(), 0);
+        MsgBox.enable();
+        MessageBoxA(0 as HWND, CString::new("After").unwrap().as_ptr(), CString::new("After").unwrap().as_ptr(), 0);
+        MsgBox.disable();
+    }
+}


### PR DESCRIPTION
A simple example of windows api hooking with detour-rs.
To compile it you will need a nightly version of rust and build it with:
```bash
rustup +nightly build
```