### PR TITLE
Remove warnings "this pointer will be invalid `CString` is deallocated" and add is_it_hooked() function

### DIFF
--- a/amsi_bypass/src/main.rs
+++ b/amsi_bypass/src/main.rs
@@ -28,10 +28,12 @@ fn main() {
     unsafe {
         // Getting the address of AmsiScanBuffer.
         let patch = [0x40, 0x40, 0x40, 0x40, 0x40, 0x40];
-        let amsi_dll = LoadLibraryA(CString::new("amsi").unwrap().as_ptr());
-        let amsi_scan_addr = GetProcAddress(amsi_dll, CString::new("AmsiScanBuffer").unwrap().as_ptr());
+        let amsi = CString::new("amsi").unwrap();
+        let amsi_dll = LoadLibraryA(amsi.as_ptr());
+        let amsi_scan_buffer = CString::new("AmsiScanBuffer").unwrap();
+        let amsi_scan_addr = GetProcAddress(amsi_dll, amsi_scan_buffer.as_ptr());
         let mut old_permissions: DWORD = 0;
-        
+
         // Overwrite this address with nops.
         if VirtualProtect(amsi_scan_addr.cast(), 6, PAGE_READWRITE, &mut old_permissions) == FALSE {
             panic!("[-] Failed to change protection.");

--- a/amsi_bypass/src/main.rs
+++ b/amsi_bypass/src/main.rs
@@ -18,7 +18,6 @@ use winapi::{
             DWORD, 
             FALSE
         },
-        ntdef::NULL
     }
 };
 

--- a/is_it_hooked/Cargo.toml
+++ b/is_it_hooked/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "is_it_hooked"
+version = "0.1.0"
+authors = ["g0h4n"]
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dependencies]
+winapi = {version = "0.3.9", features =["processthreadsapi","memoryapi","libloaderapi"]}

--- a/is_it_hooked/src/main.rs
+++ b/is_it_hooked/src/main.rs
@@ -1,0 +1,55 @@
+use winapi::{
+    um::{
+        memoryapi::ReadProcessMemory,
+        libloaderapi::{LoadLibraryA,GetProcAddress},
+        processthreadsapi::GetCurrentProcess,
+    }, 
+    shared::minwindef::LPVOID,
+    ctypes::c_void,
+};
+use std::ptr;
+
+fn main() {    
+    if is_it_hooked("NtAllocateVirtualMemory") {
+        // Use unhooking <https://github.com/trickster0/OffensiveRust/tree/master/Unhooking>
+        println!("[?] Use unhooking <https://github.com/trickster0/OffensiveRust/tree/master/Unhooking>");
+    }
+}
+
+/// Function to detecting hooked syscalls
+fn is_it_hooked(api_name: &str) -> bool {
+    // <https://github.com/TheD1rkMtr/UnhookingPatch/blob/main/PatchingAPI/src/PatchingAPI.cpp#L73>
+    // BOOL isItHooked(LPVOID addr) {
+    //     BYTE stub[] = "\x4c\x8b\xd1\xb8";
+    //     if (memcmp(addr, stub, 4) != 0)
+    //         return TRUE;
+    //     return FALSE;
+    // }
+    unsafe {
+        let modu = format!("{}{}{}{}{}.dll{}","n","t","d","l","l","\0");
+        let handle = LoadLibraryA(modu.as_ptr() as *const i8);
+        let mthd = format!("{}\0",api_name);
+        let mini = GetProcAddress(handle, mthd.as_str().as_ptr() as *const i8);
+        let mut reader: [u8; 4] = *b"\x00\x00\x00\x00";
+        // <https://learn.microsoft.com/fr-fr/windows/win32/api/memoryapi/nf-memoryapi-readprocessmemory>
+        let _status = ReadProcessMemory(
+            GetCurrentProcess(),
+            mini as *mut c_void,
+            &mut reader as *mut _ as LPVOID,
+            4,
+            ptr::null_mut()
+        );
+        // Interesting functions/syscalls, starting with Nt|Zw, before hooking, start with opcodes: 4c 8b d1 b8
+        // <https://www.ired.team/offensive-security/defense-evasion/detecting-hooked-syscall-functions>
+        let stub: &[u8; 4] = b"\x4C\x8B\xD1\xB8";
+        if &reader != stub {
+            // If &reader start with (233 == E9) opcode for near jump
+            println!("[!] {} hooked. {:02x?}", &api_name, reader);
+            return true
+        }
+        else {
+            println!("[+] {} not hooked. {:02x?}", &api_name, reader);
+            return false
+        }
+    }
+}


### PR DESCRIPTION
Hello!

Thanks for your works!
I just removed the following 3 warnings.

```
warning: unused import: `ntdef::NULL`
  --> src/main.rs:21:9
   |
21 |         ntdef::NULL
   |         ^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: getting the inner pointer of a temporary `CString`
  --> src/main.rs:31:67
   |
31 |         let amsi_dll = LoadLibraryA(CString::new("amsi").unwrap().as_ptr());
   |                                     ----------------------------- ^^^^^^ this pointer will be invalid
   |                                     |
   |                                     this `CString` is deallocated at the end of the statement, bind it to a variable to extend its lifetime
   |
   = note: `#[warn(temporary_cstring_as_ptr)]` on by default
   = note: pointers do not have a lifetime; when calling `as_ptr` the `CString` will be deallocated at the end of the statement because nothing is referencing it as far as the type system is concerned
   = help: for more information, see https://doc.rust-lang.org/reference/destructors.html

warning: getting the inner pointer of a temporary `CString`
  --> src/main.rs:32:95
   |
32 |         let amsi_scan_addr = GetProcAddress(amsi_dll, CString::new("AmsiScanBuffer").unwrap().as_ptr());
   |                                                       --------------------------------------- ^^^^^^ this pointer will be invalid
   |                                                       |
   |                                                       this `CString` is deallocated at the end of the statement, bind it to a variable to extend its lifetime
   |
   = note: pointers do not have a lifetime; when calling `as_ptr` the `CString` will be deallocated at the end of the statement because nothing is referencing it as far as the type system is concerned
   = help: for more information, see https://doc.rust-lang.org/reference/destructors.html

warning: `amsi_bypass` (bin "amsi_bypass") generated 3 warnings
```
<img width="941" alt="image" src="https://user-images.githubusercontent.com/18140652/217484633-ccd1e812-bb2b-45b6-a059-990821a23c13.png">

New result:
<img width="669" alt="image" src="https://user-images.githubusercontent.com/18140652/217485976-2af04260-80e5-480a-85b5-2487ec112fc9.png">
