### PR TITLE
Added rust-shellcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ My experiments in weaponizing [Rust](https://www.rust-lang.org/) for implant dev
 | [memN0ps: pemadness-rs](https://github.com/memN0ps/pemadness-rs/blob/main/pemadness/src/lib.rs)                                                   | Rusty Portable Executable Parsing Library (PE Parsing Library) using `windows-sys`                                                                                                                                                       |
 | [memN0ps: mimiRust](https://github.com/memN0ps/mimiRust/blob/main/src/main.rs)                                                          | Mimikatz made in Rust by @ThottySploit. The original author deleted their GitHub account, so it's been uploaded for community use.                                                                                                                                                   |
 | [memN0ps and trickster0: ekko-rs](https://github.com/memN0ps/ekko-rs/blob/master/src/ekko.rs)                                                          |  Rusty Ekko - Sleep Obfuscation in Rust using windows-sys.                                                                                                                                                   |
+|[b1nhack: rust-shellcode](https://github.com/b1nhack/rust-shellcode)									| Rust uses different techniques to implement shellcode runner for offensive operations.																									|
 
 
 ## Compiling the examples in this repo


### PR DESCRIPTION
`rust-shellcode` uses different techniques to implement shellcode runner for offensive operations :D